### PR TITLE
Equipe 9 - Correção Bug Projeção e Create Table Com Quebra de Linha Validação Ao Final

### DIFF
--- a/Fonte/interface/parser.c
+++ b/Fonte/interface/parser.c
@@ -345,7 +345,7 @@ int interface() {
                 }
             }
 
-            printf("ERROR: syntax error.\n");
+            if (strlen(GLOBAL_PARSER.error) == 0) printf("ERROR: syntax error.\n");
             GLOBAL_PARSER.noerror = 1;
         }
 
@@ -368,4 +368,8 @@ void yyerror(char *s, ...) {
   vfprintf(stderr, s, ap);
   fprintf(stderr, "\n");
   */
+}
+
+void addError(char *msg) {
+     strncpy(GLOBAL_PARSER.error, msg, sizeof(GLOBAL_PARSER.error) - 1);
 }

--- a/Fonte/interface/parser.h
+++ b/Fonte/interface/parser.h
@@ -126,3 +126,5 @@ void clearGlobalStructs();
  * dos tokens iniciais.
  */
 void setMode(char mode);
+
+void addError(char *msg);

--- a/Fonte/types.h
+++ b/Fonte/types.h
@@ -71,7 +71,8 @@ typedef struct rc_parser {
     int         noerror;        // Nenhum erro encontrado na identificação dos tokens
     int         col_count;      // Contador de colunas
     int         val_count;      // Contador de valores
-    int         consoleFlag;   // Auxiliar para não imprimir duas vezes nome=#
+    int         consoleFlag;    // Auxiliar para não imprimir duas vezes nome=#
+    char        error[256];     // Adiciona uma flag de erro
 }rc_parser;
 
 typedef struct data_base{


### PR DESCRIPTION
## 1° BUG: **Se a lista de atributos na projeção não está na ordem da criação na tabela, os valores ficam trocados**


1. Refatoração da Função ```printConsulta```:

- Alterada a assinatura para aceitar listas separadas para projeção e dados, permitindo maior flexibilidade e organização.
- Ajustado o loop de impressão para considerar as colunas de projeção, garantindo que a ordem correta seja respeitada.

2. Melhoria na Verificação de Projeção:

- Adicionado um mecanismo para verificar se todas as colunas solicitadas na projeção estão presentes na tabela base.
- Implementada uma mensagem de erro específica (```ERROR: Column '%s' not found in table.```) quando uma coluna na projeção não existe, interrompendo o processamento.

3. Correção de Bugs:

- Resolvido problema em que a ordem incorreta das colunas na projeção resultava em valores trocados durante a exibição.
- Evitada adição de tuplas incompletas ao resultado final caso a projeção fosse inválida.

## 2° BUG:  Não permite continuar digitando quando encontra um erro ao quebrar linha (digitar comando multiplas linhas)

1. **Adição de variável em `type.h`**
   - Foi adicionada uma variável global `char error[256]` ao parser, permitindo definir uma mensagem de erro sem interromper o sistema. Essa variável pode ser utilizada para armazenar mensagens de erro durante o processo de parsing.

2. **Criação da função `addError()`**
   - A função `addError()` foi implementada para atribuir a string de erro à variável `error` criada anteriormente, centralizando o tratamento de erros de forma eficiente e controlada.

3. **Ajustes no arquivo `YACC.c`**
   - O arquivo `YACC.c` foi ajustado para, ao validar a criação da tabela, verificar o conteúdo da variável `error`. Se a variável não estiver vazia, o erro contido será impresso na tela e a criação da tabela será cancelada, evitando a execução de operações inválidas.
   - Modificado o parser para que, ao invés de receber apenas um único atributo (`attribute`), ele possa receber uma lista de atributos, permitindo que essa lista seja vazia, o que indicará um erro de sintaxe.
   - Foi adicionada uma regra de validação para atributos, permitindo que eles aceitem valores além de `primary key` e `reference`. Agora, também podem aceitar valores vazios ou objetos. Caso seja recebido um objeto, isso indica que o atributo não existe, o que resulta na adição de uma mensagem de erro, "Atributo inválido".
